### PR TITLE
Bump node min version to 16 and stylelint to 14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12, 14, 16, 18]
+        node-version: [16, 18, 20]
 
     steps:
       - uses: actions/checkout@v3

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,10 +16,10 @@
         "stylelint": "^15.1.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=16"
       },
       "peerDependencies": {
-        "stylelint": ">=11"
+        "stylelint": "^14.0.0 || ^15.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -7,14 +7,14 @@
     "stylelint-order": "^6.0.2"
   },
   "engines": {
-    "node": ">=12"
+    "node": ">=16"
   },
   "devDependencies": {
     "standard": "^17.0.0",
     "stylelint": "^15.1.0"
   },
   "peerDependencies": {
-    "stylelint": ">=11"
+    "stylelint": "^14.0.0 || ^15.0.0"
   },
   "scripts": {
     "lint": "standard --fix index.js test/*.js",


### PR DESCRIPTION
This change drops support for Node v12 and v14 to match the dependent `stylelint-order` package that was changed in [version 6.0.0](https://github.com/hudochenkov/stylelint-order/releases/tag/6.0.0) of their release. It also matches `stylelint-order`'s `peerDependencies` to avoid future conflicts.

Node v20 was also added to the testing matrix to support it going forwards.

This should unblock the release of v10 as all tests will pass, allowing a release.